### PR TITLE
(doc) Fix detection of bots via user agent

### DIFF
--- a/Application.cfc
+++ b/Application.cfc
@@ -45,7 +45,7 @@
 		<cfset this.botAgents = __plusMinusStateMachine(this.defaultAgents, this.botagents) />
 		
 		<cfset this.defaultIPs = "" />
-		<cfset this.botAgents = __plusMinusStateMachine(this.defaultIPs, this.botIPs) />
+		<cfset this.botIPs = __plusMinusStateMachine(this.defaultIPs, this.botIPs) />
 		
 		<cfparam name="cookie.sessionScopeTested" default="false" />
 		<cfparam name="cookie.hasSessionScope" default="false" />


### PR DESCRIPTION
Prior to checkin, bot ips were erroneously assigned to bot agents resulting in only bots with empty user agents being marked as bots.

Unable to test that fix corrects issue as cookies work for a user, but the code seems to work with the change.