### PR TITLE
(doc) skin:buildlink whitespace

### DIFF
--- a/tags/webskin/buildLink.cfm
+++ b/tags/webskin/buildLink.cfm
@@ -1,5 +1,4 @@
-<cfsetting enablecfoutputonly="Yes">
-<cfsilent>
+<cfsetting enablecfoutputonly="Yes"><cfsilent>
 <!--- @@Copyright: Daemon Pty Limited 2002-2013, http://www.daemon.com.au --->
 <!--- @@License:
     This file is part of FarCry.
@@ -126,6 +125,4 @@
 		<cfset thistag.GeneratedContent=tagoutput>
 	</cfif>
 </cfif>
-</cfsilent>
-
-<cfsetting enablecfoutputonly="No">
+</cfsilent><cfsetting enablecfoutputonly="No">


### PR DESCRIPTION
When using skin:building inside a cfoutput, extraneous white space is also produced. Not a major issue unless one has code like this:

<skin:buildLink alais="home>Home Page</skin:buildLink>.

This results in "Home Page ." due to the white space.

This commit removes the extra lines introduced