### PR TITLE
FarCry 6.3.x does not have a fc-jquery library

### DIFF
--- a/packages/formtools/creditcardexpiry.cfc
+++ b/packages/formtools/creditcardexpiry.cfc
@@ -20,7 +20,7 @@
 		
 		<cfimport taglib="/farcry/core/tags/webskin" prefix="skin" />
 		
-		<skin:loadJS id="fc-jquery" />
+		<skin:loadJS id="jquery" />
 		
 		<cfparam name="arguments.stMetadata.ftValidation" default="" />
 		<cfif not listfindnocase(arguments.stMetadata.ftValidation,"creditcardexpiry")>

--- a/packages/formtools/creditcardnumber.cfc
+++ b/packages/formtools/creditcardnumber.cfc
@@ -39,7 +39,7 @@
 		
 		<cfimport taglib="/farcry/core/tags/webskin" prefix="skin" />
 		
-		<skin:loadJS id="fc-jquery" />
+		<skin:loadJS id="jquery" />
 		
 		<cfparam name="arguments.stMetadata.ftValidation" default="" />
 		<cfif not listfindnocase(arguments.stMetadata.ftValidation,"creditcard")>

--- a/packages/formtools/creditcardtype.cfc
+++ b/packages/formtools/creditcardtype.cfc
@@ -41,7 +41,7 @@
 		
 		<cfimport taglib="/farcry/core/tags/webskin" prefix="skin" />
 		
-		<skin:loadJS id="fc-jquery" />
+		<skin:loadJS id="jquery" />
 		
 		<cfif not len(arguments.stMetadata.ftClickable)>
 			<cfif structkeyexists(arguments.stMetadata,"ftWatch") and len(arguments.stMetadata.ftWatch)>

--- a/packages/formtools/image.cfc
+++ b/packages/formtools/image.cfc
@@ -169,7 +169,7 @@
 	    <cfparam name="arguments.stMetadata.ftAllowedExtensions" default="jpg,jpeg,png,gif"><!--- The extentions allowed to be uploaded --->
 	    <cfparam name="arguments.stMetadata.ftSizeLimit" default="0" />
 		
-	    <skin:loadJS id="fc-jquery" />
+	    <skin:loadJS id="jquery" />
 	    <skin:loadCSS id="jquery-ui" />
 	    <skin:loadJS id="jquery-tooltip" />
 	    <skin:loadJS id="jquery-tooltip-auto" />


### PR DESCRIPTION
FarCry 6.3 does not have a "fc-jquery" registered JS library.  Normally this doesn't cause a problem since jquery is loaded on nearly every page anyway.  

However, in the FarCry Solr Pro plugin on versions of FC that do not have fc-jquery, we create it as a copy of the regular "jquery" library so that we can just require fc-query on all versions of farCry instead of having `<cfif>` calls everywhere.

So, what is happening on 6.3.2 sites that have the solr plugin installed are loading two copies of jQuery and things like the image formtool are broken because the tooltip and other jquery plugins are not attaching to the correct instance of jquery.

So, since FC 6.3.x does not have a fc-jquery library in core, then core should not be referencing it at all so I think this commit should be accepted.