### PR TITLE
patch container debug lookup

### DIFF
--- a/packages/rules/container.cfc
+++ b/packages/rules/container.cfc
@@ -562,7 +562,7 @@ $Developer: Geoff Bowers (modius@daemon.com.au) $
 					<!--- <cfset oError.logData(oError.normalizeError(cfcatch)) /> --->
 					
 					<!--- show error if debugging --->
-					<cfif isdefined("url.debug") and url.debug EQ 1>
+					<cfif isdefined("request.mode.debug") and request.mode.debug EQ 1>
 						<cfset request.cfdumpinited = false>
 						
 						<skin:bubble title="Error with rule '#application.stcoapi[rule].displayName#'" bAutoHide="false" tags="rule,error">


### PR DESCRIPTION
Change debug lookup in URL to lookup in request.mode
This is more consistent as it can be set from the session and it is also checked against against the currently logged in user. A blind URL lookup overrides security settings and potential information from the cfdump can assist attackers