### PR TITLE
Fix for copying/duplicating files and images

### DIFF
--- a/packages/formtools/file.cfc
+++ b/packages/formtools/file.cfc
@@ -906,14 +906,14 @@
 		
 		<cfset currentlocation = application.fc.lib.cdn.ioFindFile(locations="privatefiles,publicfiles",file=currentfilename) />
 		
-		<cfif not len(currentpath)>
+		<cfif not len(currentlocation)>
 			<cfreturn "" />
 		</cfif>
 		
 		<cfif isSecured(arguments.stObject,arguments.stMetadata)>
-			<cfreturn application.fc.lib.cdn.ioCopyFile(source_location=currentlocation,source_file=currentfilename,dest_location="privatefiles",dest_file=newfilename,nameconflict="makeunique",uniqueamong="privatefiles,publicfiles") />
+			<cfreturn application.fc.lib.cdn.ioCopyFile(source_location=currentlocation,source_file=currentfilename,dest_location="privatefiles",dest_file=currentfilename,nameconflict="makeunique",uniqueamong="privatefiles,publicfiles") />
 		<cfelse>
-			<cfreturn application.fc.lib.cdn.ioCopyFile(source_location=currentlocation,source_file=currentfilename,dest_location="publicfiles",dest_file=newfilename,nameconflict="makeunique",uniqueamong="privatefiles,publicfiles") />
+			<cfreturn application.fc.lib.cdn.ioCopyFile(source_location=currentlocation,source_file=currentfilename,dest_location="publicfiles",dest_file=currentfilename,nameconflict="makeunique",uniqueamong="privatefiles,publicfiles") />
 		</cfif>
 	</cffunction>
 	

--- a/packages/formtools/image.cfc
+++ b/packages/formtools/image.cfc
@@ -1625,7 +1625,6 @@
 		<cfargument name="stMetadata" type="struct" required="false" hint="Property metadata" />
 		
 		<cfset var currentfilename = arguments.stObject[arguments.stMetadata.name] />
-		<cfset var newfilename = "" />
 		<cfset var currentlocation = "" />
 		
 		<cfif not len(currentfilename)>
@@ -1634,11 +1633,11 @@
 		
 		<cfset currentlocation = application.fc.lib.cdn.ioFindFile(locations="images",file=currentfilename) />
 		
-		<cfif isDefined("currentlocation") and not len(currentlocation)>
+		<cfif not len(currentlocation)>
 			<cfreturn "" />
 		</cfif>
 		
-		<cfreturn application.fc.lib.cdn.ioCopyFile(source_location="images",source_file=currentfilename,dest_location="images",dest_file=newfilename,nameconflict="makeunique",uniqueamong="images") />
+		<cfreturn application.fc.lib.cdn.ioCopyFile(source_location="images", source_file=currentfilename, dest_location="images", dest_file=currentfilename, nameconflict="makeunique", uniqueamong="images") />
 	</cffunction>
 	
 	<cffunction name="failed" access="public" output="false" returntype="struct" hint="This will return a struct with stMessage">


### PR DESCRIPTION
This fixes errors when trying to copy/duplicate types that has properties with ftType file and/or image.