### PR TITLE
error writing the webskin list

### DIFF
--- a/webskin/dmNavigation/webtopBodyQuickBuilder.cfm
+++ b/webskin/dmNavigation/webtopBodyQuickBuilder.cfm
@@ -273,6 +273,7 @@ $out:$
 						   data: { typename: $j('##makehtml').val() },
 						   cache: false,
 						   timeout: 10000,
+						   dataType:'html',
 						   success: function(msg){
 								$j('##displayMethods').html(msg);			     	
 						   }


### PR DESCRIPTION
On Quick Builder wheh selecting the content type the webskin often doesn't display with the error: Uncaught TypeError: Cannot read property 'ownerDocument' of undefined