### PR TITLE
FC-3094 - Can't cast String [string value] to a boolean: check if val…

### DIFF
--- a/packages/security/security.cfc
+++ b/packages/security/security.cfc
@@ -813,7 +813,8 @@
 		<cfset request.lValidStatus = request.mode.lValidStatus />
 		
 		<!--- ajax mode --->
-		<cfif (structKeyExists(arguments.stURL,"ajaxmode") and listlast(arguments.stURL.ajaxmode)) or (isdefined("form.ajaxmode") and listlast(form.ajaxmode))>
+		<cfif (structKeyExists(arguments.stURL,"ajaxmode") AND isBoolean(listlast(arguments.stURL.ajaxmode)) AND listlast(arguments.stURL.ajaxmode))
+            OR (isdefined("form.ajaxmode") AND isBoolean(listlast(form.ajaxmode)) AND listlast(form.ajaxmode))>
 			<cfset request.mode.ajax = 1 />
 		</cfif>
 		


### PR DESCRIPTION
Check if variable is a Boolean before using as a Boolean expression.