### PR TITLE
FC-3101: fixes decimal rounding issue

### DIFF
--- a/packages/dbgateways/BaseGateway.cfc
+++ b/packages/dbgateways/BaseGateway.cfc
@@ -275,7 +275,7 @@
 							<cfif NOT bFirst>,</cfif><cfset bFirst = false />
 							
 							<cfset stVal = getValueForDB(schema=arguments.schema.fields[thisfield],value=arguments.stProperties[thisfield]) />
-							<cfqueryparam cfsqltype="#stVal.cfsqltype#" null="#stVal.null#" value="#stVal.value#" />
+							<cfqueryparam attributeCollection="#stVal#" />
 						</cfif>
 					</cfloop>
 				)			
@@ -341,7 +341,7 @@
 						<cfif NOT bFirst>AND</cfif><cfset bFirst = false />
 						
 						<cfset stVal = getValueForDB(schema=arguments.schema.fields[thisfield],value=arguments.stProperties[thisfield]) />
-						#thisfield#=<cfqueryparam cfsqltype="#stVal.cfsqltype#" null="#stVal.null#" value="#stVal.value#" />
+						#thisfield#=<cfqueryparam attributeCollection="#stVal#" />
 					</cfloop>
 		</cfquery>
 		
@@ -362,7 +362,7 @@
 									<cfif NOT bFirst>,</cfif><cfset bFirst = false />
 									
 									<cfset stVal = getValueForDB(schema=arguments.schema.fields[thisfield],value=arguments.stProperties[thisfield]) />
-									#thisfield#=<cfqueryparam cfsqltype="#stVal.cfsqltype#" null="#stVal.null#" value="#stVal.value#" />
+									#thisfield#=<cfqueryparam attributeCollection="#stVal#" />
 								</cfif>
 							</cfloop>
 					WHERE	<cfset bFirst = true />
@@ -370,7 +370,7 @@
 								<cfif NOT bFirst>AND</cfif><cfset bFirst = false />
 								
 								<cfset stVal = getValueForDB(schema=arguments.schema.fields[thisfield],value=arguments.stProperties[thisfield]) />
-								#thisfield#=<cfqueryparam cfsqltype="#stVal.cfsqltype#" null="#stVal.null#" value="#stVal.value#" />
+								#thisfield#=<cfqueryparam attributeCollection="#stVal#" />
 							</cfloop>
 				</cfquery>
 				

--- a/packages/dbgateways/MSSQLGateway.cfc
+++ b/packages/dbgateways/MSSQLGateway.cfc
@@ -52,7 +52,7 @@
 					<cfset stResult.cfsqltype = "cf_sql_integer" />
 				<cfelse>
 					<cfset stResult.cfsqltype = "cf_sql_decimal" />
-                    <cfset stResult.status = listlast(arguments.schema.precision) />
+					<cfset stResult.scale = listlast(arguments.schema.precision) />
 				</cfif>
 				<cfif arguments.schema.nullable and (arguments.value eq "" or arguments.value eq "NULL")>
 					<cfset stResult.value = 0 />

--- a/packages/dbgateways/MSSQLGateway.cfc
+++ b/packages/dbgateways/MSSQLGateway.cfc
@@ -52,6 +52,7 @@
 					<cfset stResult.cfsqltype = "cf_sql_integer" />
 				<cfelse>
 					<cfset stResult.cfsqltype = "cf_sql_decimal" />
+					<cfset stResult.scale = listlast(arguments.schema.precision) />
 				</cfif>
 				<cfif arguments.schema.nullable and (arguments.value eq "" or arguments.value eq "NULL")>
 					<cfset stResult.value = 0 />

--- a/packages/dbgateways/MSSQLGateway.cfc
+++ b/packages/dbgateways/MSSQLGateway.cfc
@@ -52,7 +52,7 @@
 					<cfset stResult.cfsqltype = "cf_sql_integer" />
 				<cfelse>
 					<cfset stResult.cfsqltype = "cf_sql_decimal" />
-					<cfset stResult.scale = listlast(arguments.schema.precision) />
+                    <cfset stResult.status = listlast(arguments.schema.precision) />
 				</cfif>
 				<cfif arguments.schema.nullable and (arguments.value eq "" or arguments.value eq "NULL")>
 					<cfset stResult.value = 0 />

--- a/packages/dbgateways/MySQLGateway.cfc
+++ b/packages/dbgateways/MySQLGateway.cfc
@@ -27,7 +27,7 @@
 					<cfset stResult.cfsqltype = "cf_sql_integer" />
 				<cfelse>
 					<cfset stResult.cfsqltype = "cf_sql_decimal" />
-                    <cfset stResult.status = listlast(arguments.schema.precision) />
+					<cfset stResult.scale = listlast(arguments.schema.precision) />
 				</cfif>
 				<cfif arguments.schema.nullable and (arguments.value eq "" or arguments.value eq "NULL")>
 					<cfset stResult.value = 0 />

--- a/packages/dbgateways/MySQLGateway.cfc
+++ b/packages/dbgateways/MySQLGateway.cfc
@@ -27,7 +27,7 @@
 					<cfset stResult.cfsqltype = "cf_sql_integer" />
 				<cfelse>
 					<cfset stResult.cfsqltype = "cf_sql_decimal" />
-					<cfset stResult.scale = listlast(arguments.schema.precision) />
+                    <cfset stResult.status = listlast(arguments.schema.precision) />
 				</cfif>
 				<cfif arguments.schema.nullable and (arguments.value eq "" or arguments.value eq "NULL")>
 					<cfset stResult.value = 0 />

--- a/packages/dbgateways/MySQLGateway.cfc
+++ b/packages/dbgateways/MySQLGateway.cfc
@@ -27,6 +27,7 @@
 					<cfset stResult.cfsqltype = "cf_sql_integer" />
 				<cfelse>
 					<cfset stResult.cfsqltype = "cf_sql_decimal" />
+					<cfset stResult.scale = listlast(arguments.schema.precision) />
 				</cfif>
 				<cfif arguments.schema.nullable and (arguments.value eq "" or arguments.value eq "NULL")>
 					<cfset stResult.value = 0 />
@@ -216,7 +217,7 @@
 				</cfswitch>
 				<cfif stProp.nullable>NULL<cfelse>NOT NULL</cfif>
 				<cfset stVal = getValueForDB(schema=stProp,value=stProp.default) />
-				<cfif stProp.type neq "longchar">DEFAULT <cfqueryparam cfsqltype="#stVal.cfsqltype#" null="#stVal.null#" value="#stVal.value#" /></cfif>
+				<cfif stProp.type neq "longchar">DEFAULT <cfqueryparam attributeCollection="#stVal#" /></cfif>
 			</cfquery>
 			
 			<cfset arrayappend(stResult.results,queryresult) />
@@ -277,7 +278,7 @@
 				</cfswitch>
 				<cfif stProp.nullable>NULL<cfelse>NOT NULL</cfif>
 				<cfset stVal = getValueForDB(schema=stProp,value=stProp.default) />
-				<cfif stProp.type neq "longchar">DEFAULT <cfqueryparam cfsqltype="#stVal.cfsqltype#" null="#stVal.null#" value="#stVal.value#" /></cfif>
+				<cfif stProp.type neq "longchar">DEFAULT <cfqueryparam attributeCollection="#stVal#" /></cfif>
 			</cfquery>
 			
 			<cfset arrayappend(stResult.results,queryresult) />


### PR DESCRIPTION
fixes decimal rounding issue by passing scale attribute to `cfqueryparam` when `cfsqltype` is `cf_sql_decimal`

Discussion here:
http://discourse.farcrycore.org/t/fc7-not-saving-numeric-data-after-decimal-when-using-dbprecision-and-type-numeric/697

Jira Bug:
https://farcry.jira.com/browse/FC-3101