### PR TITLE
application.objectbroker was being reset on init with bFlush

### DIFF
--- a/packages/lib/objectBroker.cfc
+++ b/packages/lib/objectBroker.cfc
@@ -7,7 +7,9 @@
 		<cfset var bSuccess = true />
 		
 		<cfif not structKeyExists(application,"bInit") OR not application.bInit OR arguments.bFlush OR NOT structKeyExists(application, "objectBroker") OR NOT structKeyExists(application, "objectrecycler")>
-			<cfset application.objectbroker =  structNew() />
+			<cfif NOT structKeyExists(application,'objectbroker')>
+            			<cfset application.objectbroker = structNew()>
+            		</cfif>
 			
 			<!--- This Java object gathers objects that were put in the broker but marked for garbage collection --->
 			<cfset application.objectrecycler =  createObject("java", "java.lang.ref.ReferenceQueue") />


### PR DESCRIPTION
So when it tries to loop through the collection of existing caches there is none.
This occurs when you us the 'Rebuild Site' link from the tray. I've also found this to happen sometimes during initial startup of an application or an updateApp call but I can't say if it's related.

![image](https://user-images.githubusercontent.com/7389789/29146440-42870916-7db5-11e7-9e38-9e180fbc0d53.png)
