### PR TITLE
FC-3130 - added bUseInstanceCache=false

### DIFF
--- a/tags/formtools/processformobjects.cfm
+++ b/tags/formtools/processformobjects.cfm
@@ -192,7 +192,7 @@
 		</cfif>
 		
 		
-		<cfset stObj = stType.getData(Caller[attributes.r_stProperties].ObjectID) />
+		<cfset stObj = stType.getData(objectid=Caller[attributes.r_stProperties].ObjectID, bUseInstanceCache=false) />
 		<cfset bResult = structAppend(Caller[attributes.r_stProperties], stObj, false )  />
 		
 		


### PR DESCRIPTION
added bUseInstanceCache=false to ensure current data is returned

https://farcry.jira.com/projects/FC/issues/FC-3130?filter=allopenissues