### PR TITLE
CF 2018 has dropped support for requesttimeout attribute of cfschedule

### DIFF
--- a/packages/types/dmCron.cfc
+++ b/packages/types/dmCron.cfc
@@ -121,7 +121,9 @@ type properties
 <cffunction name="addJob" returntype="boolean" output="false" hint="Schedules a task on app server jobs list.">
 	<cfargument name="objectid" type="uuid" required="false">
 	<cfargument name="stobject" type="struct" required="false">
-
+	
+	<cfset var attr = structnew() />
+	
 	<cfif structKeyExists(arguments, "objectid")>
 		<cfset arguments.stobject = getData(objectid=arguments.objectid)>	
 	</cfif>
@@ -129,19 +131,22 @@ type properties
 	<cfif structIsEmpty(stobject)>
 		<cfthrow type="Application" message="Argument *stobject* is empty.">
 	</cfif>
+	
+	<cfscript>
+	attr.action = "UPDATE";
+	attr.task = "#application.applicationName#: #stobject.title#";
+	attr.operation = "HTTPRequest";
+	attr.url = "http://#cgi.HTTP_HOST##application.url.conjurer#?objectid=#stobject.objectid#&#stobject.parameters#";
+	attr.interval = "#stobject.frequency#";
+	attr.startdate = "#dateFormat(stobject.startDate,'dd/mmm/yyyy')#";
+	attr.starttime = "#timeFormat(stobject.startDate,'hh:mm tt')#";
+	attr.enddate = "#dateFormat(stobject.endDate,'dd/mmm/yyyy')#";
+	attr.endtime= "#timeFormat(stobject.endDate,'hh:mm tt')#";
+	attr.requesttimeout = "#stobject.timeout#";
+	</cfscript>
 
-	<cfschedule 
-		action="UPDATE" 
-		task = "#application.applicationName#: #stobject.title#"
-		operation = "HTTPRequest"
-		url = "http://#cgi.HTTP_HOST##application.url.conjurer#?objectid=#stobject.objectid#&#stobject.parameters#"
-		interval = "#stobject.frequency#"
-		startdate = "#dateFormat(stobject.startDate,'dd/mmm/yyyy')#"
-		starttime = "#timeFormat(stobject.startDate,'hh:mm tt')#"
-		enddate = "#dateFormat(stobject.endDate,'dd/mmm/yyyy')#"
-		endtime= "#timeFormat(stobject.endDate,'hh:mm tt')#"
-		requesttimeout = "#stobject.timeout#">
-
+	<cfschedule attributeCollection="#attr#">
+		
 	<cfreturn true>
 </cffunction>
 


### PR DESCRIPTION
ColdFusion 2018 has dropped support for the `requesttimeout` attribute of `<cfschedule>`.  It will throw an error if you use this attribute.

That said, if you have the setting enabled in the CF Admin to allow "extra" attributes when using an `attributeCollection`, then it will allow it.

So we can change the code to use an attribute collection which is passed to the cfschedule tag.  This will allow older versions of ACF to still use the `requesttimeout` attribute while keeping CF 2018 from throwing an error.