### PR TITLE
FC-3157 - added ability to return file attibutes in ioGetDirectoryListing()

### DIFF
--- a/packages/cdn/local.cfc
+++ b/packages/cdn/local.cfc
@@ -276,18 +276,18 @@
 	<cffunction name="ioGetDirectoryListing" returntype="query" access="public" output="false" hint="Returns a query of the directory containing a 'file' column only. This filename will be equivilent to what is passed into other CDN functions.">
 		<cfargument name="config" type="struct" required="true" />
 		<cfargument name="dir" type="string" required="true" />
+		<cfargument name="listinfo" type="string" required="false" default="name" hint="name or all" />
 		
 		<cfset var qDir = "" />
 		
-		<cfdirectory action="list" directory="#getFullPath(config=arguments.config,file=arguments.dir)#" recurse="true" type="file" listinfo="name" name="qDir" />
+		<cfdirectory action="list" directory="#getFullPath(config=arguments.config,file=arguments.dir)#" recurse="true" type="file" listinfo="#arguments.listinfo#" name="qDir" sort="name" />
 		
 		<cfquery dbtype="query" name="qDir">
-			SELECT 		'#arguments.dir#/' + name AS file 
+			SELECT 		'#arguments.dir#/' + name AS file, *
 			FROM 		qDir 
 			WHERE		not name like '%/.%'
-			ORDER BY 	name
 		</cfquery>
-		
+
 		<cfreturn qDir />
 	</cffunction>
 	

--- a/packages/cdn/s3.cfc
+++ b/packages/cdn/s3.cfc
@@ -819,6 +819,7 @@
 	<cffunction name="ioGetDirectoryListing" returntype="query" access="public" output="false" hint="Returns a query of the directory containing a 'file' column only. This filename will be equivilent to what is passed into other CDN functions.">
 		<cfargument name="config" type="struct" required="true" />
 		<cfargument name="dir" type="string" required="true" />
+		<cfargument name="listinfo" type="string" required="false" default="name" hint="name or all" />
 		
 		<cfset var qDir = "" />
 		<cfset var s3path = "s3://#arguments.config.accessKeyId#:#arguments.config.awsSecretKey#@#arguments.config.bucket##lcase(arguments.config.pathPrefix)##lcase(arguments.dir)#" />
@@ -827,13 +828,14 @@
 			<cfreturn querynew("file") />
 		</cfif>
 
-		<cfdirectory action="list" directory="#s3path#" recurse="true" listinfo="name" name="qDir" />
+		<cfdirectory action="list" directory="#s3path#" recurse="true" listinfo="#arguments.listinfo#" name="qDir" sort="name" />
 		
-		<cfquery dbtype="query" name="qDir">
-			SELECT 		'/' + name AS file
-			FROM 		qDir 
-			ORDER BY 	name
-		</cfquery>
+		<cfif arguments.listinfo EQ "name">
+			<cfset QueryAddColumn( qDir, "file")>
+			<cfloop query="qDir">
+				<cfset querysetcell(qDir,"file","/" & qDir.name, qDir.CurrentRow) />
+			</cfloop>
+		</cfif>
 		
 		<cfreturn qDir />
 	</cffunction>

--- a/packages/lib/cdn.cfc
+++ b/packages/lib/cdn.cfc
@@ -784,12 +784,13 @@
 	<cffunction name="ioGetDirectoryListing" returntype="query" access="public" output="false" hint="Lists the files the specfied directory.">
 		<cfargument name="location" type="string" required="true" />
 		<cfargument name="dir" type="string" required="false" default="" />
+		<cfargument name="listinfo" type="string" required="false" default="name" hint="name or all" />
 		
 		<cfset var config = this.locations[arguments.location] />
 		
 		<cfset arguments.dir = normalizePath(arguments.dir) />
 		
-		<cfreturn this.cdns[config.cdn].ioGetDirectoryListing(config=config,dir=arguments.dir) />
+		<cfreturn this.cdns[config.cdn].ioGetDirectoryListing(config=config,dir=arguments.dir, listinfo=arguments.listinfo) />
 	</cffunction>
 	
 </cfcomponent>


### PR DESCRIPTION
### usage:
`qExistingFiles = application.fc.lib.cdn.ioGetDirectoryListing(location='privatefiles',dir='/imports', listinfo='all')`