### PR TITLE
FC-3160 - add bDebug (default false) to location config

### DIFF
--- a/packages/cdn/ftp.cfc
+++ b/packages/cdn/ftp.cfc
@@ -91,6 +91,10 @@
 		<cfelse>
 			<cfset application.fapi.throw(message="no '{1}' value defined",type="cdnconfigerror",detail=serializeJSON(arguments.config),substituteValues=[ 'urlPathPrefix' ]) />
 		</cfif>
+
+		<cfif not structkeyexists(st,"bDebug")>
+			<cfset st["bDebug"] = false />
+		</cfif>
 		
 		<cfreturn st />
 	</cffunction>

--- a/packages/cdn/local.cfc
+++ b/packages/cdn/local.cfc
@@ -27,6 +27,10 @@
 			<cfset st.urlpath = rereplacenocase(st.urlpath,"^https?:","") />
 		</cfif>
 		
+		<cfif not structkeyexists(st,"bDebug")>
+			<cfset st["bDebug"] = false />
+		</cfif>
+		
 		<cfreturn st />
 	</cffunction>
 	


### PR DESCRIPTION
add bDebug (default false) to location config to reduce amount of information logging in S3 CDN library

**usage:**
```
	<cfset application.fc.lib.cdn.setLocation(
	    name = "images",
	    cdn = "s3",
	    accessKeyId = accessKeyId,
	    awsSecretKey = awsSecretKey,
	    bucket = bucket,
	    region = region,
	    security = "public",
	    pathPrefix = bucketPrefix ,
	    bDebug=true
	) />
```