### PR TITLE
FC-3161 - ioGetDirectoryListing() use getS3Path()

### DIFF
--- a/packages/cdn/s3.cfc
+++ b/packages/cdn/s3.cfc
@@ -981,7 +981,7 @@
 		<cfargument name="listinfo" type="string" required="false" default="name" hint="name or all" />
 		
 		<cfset var qDir = "" />
-		<cfset var s3path = "s3://#arguments.config.accessKeyId#:#arguments.config.awsSecretKey#@#arguments.config.bucket##lcase(arguments.config.pathPrefix)##lcase(arguments.dir)#" />
+		<cfset var s3path = getS3Path(config=arguments.config,file=arguments.dir) />
 		
 		<cfif not directoryExists(s3Path)>
 			<cfreturn querynew("file") />


### PR DESCRIPTION
changed
`<cfset var s3path = "s3://#arguments.config.accessKeyId#:#arguments.config.awsSecretKey#@#arguments.config.bucket##lcase(arguments.config.pathPrefix)##lcase(arguments.dir)#" /> `

To	
`<cfset var s3path = getS3Path(config=arguments.config,file=arguments.dir) />`