### PR TITLE
Bulk Image Upload & special characters

### DIFF
--- a/packages/events/bulkupload.cfc
+++ b/packages/events/bulkupload.cfc
@@ -29,7 +29,7 @@
 			typename = stObject.typename,
 			objectid = stObject.objectid,
 			existingFile = "",
-			localFile = application.fc.lib.cdn.ioGetFileLocation(location="temp", file=arguments.details.tempfile).path,
+			localFile = application.fc.lib.cdn.ioGetFileLocation(location="temp", file=arguments.details.tempfile,bRetrieve="true").path,
 			destination = application.fapi.getPropertyMetadata(stObject.typename, arguments.details.targetfield, "ftDestination"),
 			secure = application.fapi.getPropertyMetadata(stObject.typename, arguments.details.targetfield, "ftSecure", false),
 			status = structKeyExists(stObject, "status") ? stObject.status : "approved",


### PR DESCRIPTION
If an image file name has any special characters it fails to be found because ioGetFileLocation will default to normalizePath removing any special characters for it’s lookup.