### PR TITLE
i18nutil patch

### DIFF
--- a/packages/farcry/i18nUtil.cfc
+++ b/packages/farcry/i18nUtil.cfc
@@ -12,7 +12,10 @@ this CFC contains a few util I18N functions. all valid java locales	are supporte
 of cfobject. 
 
 methods in this CFC:
-	
+
+	- getLocalesAsQuery returns QUERY of java style locales (en_US,etc.)
+	and their corresponding names (English (United States),etc.) available on this server. PUBLIC
+		
 	- getLocales returns LIST of java style locales (en_US,etc.) available on this server. PUBLIC
 	
 	- getLocaleNames returns LIST of java style locale names available on this server. PUBLIC
@@ -31,6 +34,25 @@ methods in this CFC:
 	one required argument, thisLocale. returns string. PUBLIC
  --->
 <cfset variables.aLocale = createObject("java","java.util.Locale")>
+
+<cffunction access="public" name="getLocalesAsQuery" output="No" returntype="query" hint="returns query of locales with their names" bDocument="true">
+	<cfscript>
+		var orgLocales=aLocale.getAvailableLocales();
+		var qLocales=queryNew("value,name"); /* allow list to be used directly with list formtool */
+		var i=0;
+		var thisName="";
+		for (i=1; i LTE arrayLen(orgLocales); i=i+1) {
+			if (listLen(orgLocales[i],"_") EQ 2) {
+				if (left(orgLocales[i],2) EQ "ar" or left(orgLocales[i],2) EQ "iw")
+					thisName=chr(8235)&orgLocales[i].getDisplayName(orgLocales[i])&chr(8234);
+				else
+					thisName=orgLocales[i].getDisplayName(orgLocales[i]);
+				queryAddRow(qLocales, {"value"=orgLocales[i], "name"=replace(thisName, ",", "", "ALL")});
+			} // if locale more than language
+		} //for
+		return qLocales;
+	</cfscript>
+</cffunction>
 
 <cffunction access="public" name="getLocales" output="No" returntype="string" hint="returns list of locales" bDocument="true">
 	<cfscript>

--- a/packages/types/dmProfile.cfc
+++ b/packages/types/dmProfile.cfc
@@ -133,17 +133,17 @@ OBJECT METHODS
 		<cfreturn super.setData(argumentCollection=arguments) />
 	</cffunction>
 
-	<cffunction name="getLocales" access="public" output="false" returntype="string" hint="Returns the list of supported locales">
-		<cfset var locales = application.i18nUtils.getLocales() />
-		<cfset var localeNames = application.i18nUtils.getLocaleNames() />
-		<cfset var result = "" />
-		<cfset var locale = "" />
+	<cffunction name="getLocales" access="public" output="false" returntype="query" hint="Returns the list of supported locales">
+		<cfset var qLocales = application.i18nUtils.getLocalesAsQuery() />
+		<cfset var qResult = queryNew("value,name") />
 
-		<cfloop list="#application.locales#" index="locale">
-			<cfset result = listappend(result,"#locale#:#listgetat(localeNames,listfind(locales,locale))#") />
-		</cfloop>
+		<cfquery dbtype="query" name="qResult" >
+			SELECT value, name
+			FROM qLocales
+			WHERE value in (<cfqueryparam value="#application.locales#" cfsqltype="cf_sql_varchar" list="yes"/>)
+		</cfquery>
 		
-		<cfreturn result />
+		<cfreturn qResult />
 	</cffunction>
 	
 	<cffunction name="createProfile" access="PUBLIC" hint="Create new profile object using existing dmSec information. Returns newly created profile as a struct." returntype="struct" output="true">


### PR DESCRIPTION
Add query method to i18nutil to return locales as a query. Update dmProfile to use new method.

This fixes list related issues as described on the forum: https://discourse.farcrycore.org/t/profile-locales/1741

This has only been tested with Lucee 5.3.12.1. Planning to test with ColdFusion 2021 Standard. Open to suggestions for other tests.