### PR TITLE
Bulk Upload Fails if there is a ftSizeLimit on the SourceImage

### DIFF
--- a/packages/formtools/image.cfc
+++ b/packages/formtools/image.cfc
@@ -966,7 +966,7 @@
 			
 		<cfelse>
 			
-			<cfif arguments.sizeLimit and arguments.sizeLimit lt stFile.fileSize>
+			<cfif arguments.sizeLimit and arguments.sizeLimit lt application.fc.lib.cdn.ioGetFileSize(location="images",file=listLast(arguments.existingfile, "/\"))>
 				<cfset stResult = failed(value=arguments.existingfile,message="#arguments.localfile# is not within the file size limit of #round(arguments.sizeLimit/1048576)#MB") />
 			<cfelseif listFindNoCase(arguments.allowedExtensions,listlast(arguments.localfile,"."))>
 				<cfset uploadFileName = application.fc.lib.cdn.ioMoveFile(source_localpath=arguments.localfile,dest_location="images",dest_file=arguments.destination & "/" & getFileFromPath(arguments.localfile),nameconflict="makeunique") />


### PR DESCRIPTION
The referenced stFile.fileSize doesn't exist because stFile is an empty struct. This error only occurs when bulk uploading files to a type where the image has a ftSizeLimit (eg on the SourceImage of dmImage).
![image](https://github.com/farcrycore/core/assets/7389789/e0c429e8-e63d-4f6e-a24b-b597b0c77f6b)
